### PR TITLE
Ignore comments in xinitrc

### DIFF
--- a/ufetch-arch
+++ b/ufetch-arch
@@ -12,7 +12,7 @@ KERNEL="$(uname -sr)"
 UPTIME="$(uptime -p | sed s:"up "::)"
 PACKAGES="$(pacman -Q | wc -l)"
 # shell is already defined
-WM="$(tail -n 1 "${HOME}/.xinitrc" | cut -d " " -f2)"
+WM="$(grep -v "^#" "${HOME}/.xinitrc" | tail -n 1 | cut -d " " -f2)"
 
 ## DEFINE COLORS
 


### PR DESCRIPTION
This fix makes the wm detection a little better by ignoring comments in xinitrc.
