### PR TITLE
Test for user-defined $WM variable

### DIFF
--- a/ufetch-arch
+++ b/ufetch-arch
@@ -12,7 +12,9 @@ KERNEL="$(uname -sr)"
 UPTIME="$(uptime -p | sed s:"up "::)"
 PACKAGES="$(pacman -Q | wc -l)"
 # shell is already defined
-WM="$(grep -v "^#" "${HOME}/.xinitrc" | tail -n 1 | cut -d " " -f2)"
+if [[ -z "$WM" ]]; then
+	WM="$(grep -v "^#" "${HOME}/.xinitrc" | tail -n 1 | cut -d " " -f2)"
+fi
 
 ## DEFINE COLORS
 

--- a/ufetch-gentoo
+++ b/ufetch-gentoo
@@ -12,7 +12,9 @@ KERNEL="$(uname -sr)"
 UPTIME="$(uptime -p | sed s:'up ':'':)"
 PACKAGES="$(ls -d /var/db/pkg/*/* | wc -l)"
 # shell is already defined
-WM=$(tail -n 1 "$HOME/.xinitrc" | cut -d ' ' -f3)
+if [[ -z "$WM" ]]; then
+	WM=$(tail -n 1 "$HOME/.xinitrc" | cut -d ' ' -f3)
+fi
 
 ## DEFINE COLORS
 


### PR DESCRIPTION
Parsing xinitrc isn't flawless, particularly when people are using window managers like dwm or 2bwm that frequently get wrapped in a while loop. When that happens, the script doesn't parse the window manager properly. For example, my xinitrc has this in it:

```
while :; do
  ~/git/2bwm/2bwm
done
```

And when I run ufetch, it thinks that my wm is "done" when it's actually 2bwm.
