### PR TITLE
OpenBSD Package Count

### DIFF
--- a/ufetch-openbsd
+++ b/ufetch-openbsd
@@ -9,7 +9,7 @@ host="$(hostname)"
 os="$(uname -sr)"
 kernel="$(uname -v)"
 uptime="$(uptime | awk -F, '{sub(".*up ",x,$1);print $1}' | sed -e 's/^[ \t]*//')"
-packages="$(pkg_info -A | wc -l | sed -e 's/^[ \t]*//')"
+packages="$(ls -d /var/db/pkg/* | wc -l | awk '{$1=$1};1')"
 shell="$(basename ${SHELL})"
 if [ -z "${WM}" ]; then
 	WM="$(tail -n 1 "${HOME}/.xinitrc" | cut -d ' ' -f 2)"

--- a/ufetch-openbsd
+++ b/ufetch-openbsd
@@ -9,7 +9,7 @@ host="$(hostname)"
 os="$(uname -sr)"
 kernel="$(uname -v)"
 uptime="$(uptime | awk -F, '{sub(".*up ",x,$1);print $1}' | sed -e 's/^[ \t]*//')"
-packages="$(ls -d /var/db/pkg/* | wc -l | awk '{$1=$1};1')"
+packages="$(ls -d /var/db/pkg/* | wc -l | sed -e 's/^[ \t]*//')"
 shell="$(basename ${SHELL})"
 if [ -z "${WM}" ]; then
 	WM="$(tail -n 1 "${HOME}/.xinitrc" | cut -d ' ' -f 2)"


### PR DESCRIPTION
The current implementation of getting the package count using pkg_info blocks when the user is using any other pkg_* utility. So if a user is installing some packages, ufetch will just hang until the packages are done installing. I realized that counting the directories in `/var/db/pkg` will get the package count without blocking.